### PR TITLE
usnic: Update the names of fabrics and domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config.h
 config.h.in
 config.h.in~
 config.log
+config.lt
 config.status
 configure
 libtool

--- a/include/fi_proto.h
+++ b/include/fi_proto.h
@@ -112,7 +112,8 @@ struct ofi_ctrl_hdr {
 enum {
 	ofi_op_msg,
 	ofi_op_tagged,
-	ofi_op_read,
+	ofi_op_read_req,
+	ofi_op_read_rsp,
 	ofi_op_write,
 	ofi_op_atomic,
 };
@@ -133,7 +134,7 @@ enum {
  * size: Size of data transfer
  * data: Remote CQ data, if available
  * tag: Message tag, used for tagged operations only
- * iov_len: Length of destination iov, used for RMA operations
+ * iov_count: Count of destination iov, used for RMA operations
  * atomic: Control fields for atomic operations
  * resv: Reserved, used for msg operations
  */
@@ -148,12 +149,13 @@ struct ofi_op_hdr {
 	uint64_t		data;
 	union {
 		uint64_t	tag;
-		uint8_t		iov_len;
+		uint8_t		iov_count;
 		struct {
 			uint8_t	datatype;
 			uint8_t	op;
-			uint8_t ioc_len;
+			uint8_t ioc_count;
 		} atomic;
+		uint64_t	peer_id;
 		uint64_t	resv;
 	};
 };

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -140,7 +140,7 @@ struct util_domain {
 	atomic_t		ref;
 	const struct fi_provider *prov;
 
-	const char		*name;
+	char			*name;
 	uint64_t		caps;
 	uint64_t		mode;
 	uint32_t		addr_format;

--- a/include/windows/netinet/in.h
+++ b/include/windows/netinet/in.h
@@ -1,4 +1,9 @@
 
-#pragma once
+#ifndef _FI_WIN_NETINET_IN_H_
+#define _FI_WIN_NETINET_IN_H_
 
+#include <WinSock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
 
+#endif /* _FI_WIN_NETINET_IN_H_ */

--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -359,9 +359,10 @@ The total number of inserted addresses will be nodecnt x svccnt.
 ## fi_av_remove
 
 fi_av_remove removes a set of addresses from an address vector.  All
-resources associated with the indicated addresses are released, and no
-future references to either the mapped address (in the case of
-FI_AV_MAP) or index (FI_AV_TABLE) are allowed.
+resources associated with the indicated addresses are released.
+The removed address - either the mapped address (in the case of FI_AV_MAP)
+or index (FI_AV_TABLE) - is invalid until it is returned again by a
+new fi_av_insert.
 
 The use of fi_av_remove is an optimization that applications may use
 to free memory allocated with addresses that will no longer be

--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -283,6 +283,22 @@ is the destination host is locally connected, and `1` otherwise.
 
 See fi_ext_usnic.h for more details.
 
+# VERSION DIFFERENCES
+
+## New naming convention for fabric/domain starting with libfabric v1.4
+
+The release of libfabric v1.4 introduced a new naming convention for fabric and domain. However the usNIC provider
+remains backward compatible with applications supporting the old scheme and decides which one to use based on
+the version passed to `fi_getinfo`:
+
+* When `FI_VERSION(1,4)` or higher is used:
+     - fabric name is the network address with the CIDR notation (i.e., `a.b.c.d/e`)
+     - domain name is the usNIC Linux interface name (i.e., `usnic_X`)
+
+* When a lower version number is used, like `FI_VERSION(1, 3)`, it follows the same behavior the usNIC provider exhibited in libfabric <= v1.3:
+     - fabric name is the usNIC Linux interface name (i.e., `usnic_X`)
+     - domain name is `NULL`
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/man/man3/fi_av.3
+++ b/man/man3/fi_av.3
@@ -1,4 +1,4 @@
-.TH "fi_av" "3" "2016\-08\-11" "Libfabric Programmer\[aq]s Manual" "\@VERSION\@"
+.TH "fi_av" "3" "2016\-08\-24" "Libfabric Programmer\[aq]s Manual" "\@VERSION\@"
 .SH NAME
 .PP
 fi_av \- Address vector operations
@@ -348,9 +348,10 @@ The total number of inserted addresses will be nodecnt x svccnt.
 .SS fi_av_remove
 .PP
 fi_av_remove removes a set of addresses from an address vector.
-All resources associated with the indicated addresses are released, and
-no future references to either the mapped address (in the case of
-FI_AV_MAP) or index (FI_AV_TABLE) are allowed.
+All resources associated with the indicated addresses are released.
+The removed address \- either the mapped address (in the case of
+FI_AV_MAP) or index (FI_AV_TABLE) \- is invalid until it is returned
+again by a new fi_av_insert.
 .PP
 The use of fi_av_remove is an optimization that applications may use to
 free memory allocated with addresses that will no longer be accessed.

--- a/prov/rxd/Makefile.include
+++ b/prov/rxd/Makefile.include
@@ -7,6 +7,7 @@ _rxd_files = \
 	prov/rxd/src/rxd_av.c		\
 	prov/rxd/src/rxd_cq.c		\
 	prov/rxd/src/rxd_ep.c		\
+	prov/rxd/src/rxd_rma.c		\
 	prov/rxd/src/rxd.h
 
 if HAVE_RXD_DL

--- a/prov/rxd/src/rxd_attr.c
+++ b/prov/rxd/src/rxd_attr.c
@@ -33,7 +33,8 @@
 #include "rxd.h"
 
 struct fi_tx_attr rxd_tx_attr = {
-	.caps = FI_MSG | FI_TAGGED | FI_SEND,
+	.caps = FI_MSG | FI_TAGGED | FI_SEND | FI_RMA | FI_WRITE |
+	FI_READ | FI_RMA_EVENT | FI_REMOTE_READ | FI_REMOTE_WRITE,
 	.comp_order = FI_ORDER_STRICT,
 	.inject_size = 0,
 	.size = (1ULL << RXD_MAX_TX_BITS),
@@ -41,7 +42,7 @@ struct fi_tx_attr rxd_tx_attr = {
 };
 
 struct fi_rx_attr rxd_rx_attr = {
-	.caps = FI_MSG | FI_TAGGED | FI_RECV | FI_SOURCE,
+	.caps = FI_MSG | FI_TAGGED | FI_RECV | FI_SOURCE | FI_RMA_EVENT,
 	.comp_order = FI_ORDER_STRICT,
 	.total_buffered_recv = 0,
 	.size = (1ULL << RXD_MAX_RX_BITS),
@@ -80,7 +81,9 @@ struct fi_fabric_attr rxd_fabric_attr = {
 };
 
 struct fi_info rxd_info = {
-	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE | FI_TAGGED,
+	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE | FI_TAGGED |
+	FI_RMA | FI_WRITE | FI_READ | FI_RMA_EVENT |
+	FI_REMOTE_WRITE | FI_REMOTE_READ,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxd_tx_attr,
 	.rx_attr = &rxd_rx_attr,

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -255,8 +255,10 @@ int rxd_handle_ack(struct rxd_ep *ep, struct ofi_ctrl_hdr *ctrl,
 	case RXD_PKT_LAST:
 		rxd_ep_free_acked_pkts(ep, tx_entry, ctrl->seg_no);
 		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "reporting TX completion : %p\n", tx_entry);
-		rxd_cq_report_tx_comp(ep->tx_cq, tx_entry);
-		rxd_tx_entry_done(ep, tx_entry);
+		if (tx_entry->op_type != RXD_TX_READ_REQ) {
+			rxd_cq_report_tx_comp(ep->tx_cq, tx_entry);
+			rxd_tx_entry_done(ep, tx_entry);
+		}
 		break;
 	default:
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid pkt type\n");
@@ -533,20 +535,27 @@ void rxd_report_rx_comp(struct rxd_cq *cq, struct rxd_rx_entry *rx_entry)
 		cq_entry.tag = rx_entry->trecv->msg.tag;
 		break;
 
-	case ofi_op_read:
-		cq_entry.flags |= (FI_RMA | FI_REMOTE_READ);
-		break;
-
-	case ofi_op_write:
-		cq_entry.flags |= (FI_RMA | FI_REMOTE_WRITE);
-		break;
-
 	case ofi_op_atomic:
 		cq_entry.flags |= FI_ATOMIC;
 		break;
 
+	case ofi_op_write:
+		if (!(rx_entry->op_hdr.flags & OFI_REMOTE_CQ_DATA))
+			return;
+
+		cq_entry.flags |= (FI_RMA | FI_REMOTE_WRITE);
+		cq_entry.op_context = rx_entry->trecv->msg.context;
+		cq_entry.len = rx_entry->done;
+		cq_entry.buf = rx_entry->write.iov[0].iov_base;
+		cq_entry.data = rx_entry->op_hdr.data;
+		break;
+
+	case ofi_op_read_rsp:
+		return;
+
 	default:
-		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type\n");
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type: %d\n",
+			rx_entry->op_hdr.op);
 		break;
 	}
 
@@ -591,6 +600,25 @@ void rxd_cq_report_tx_comp(struct rxd_cq *cq, struct rxd_tx_entry *tx_entry)
 		cq_entry.data = tx_entry->op_hdr.data;
 		cq_entry.tag = tx_entry->tmsg.tmsg.tag;
 		break;
+
+	case RXD_TX_WRITE:
+		cq_entry.flags = (FI_TRANSMIT | FI_RMA | FI_WRITE);
+		cq_entry.op_context = tx_entry->write.msg.context;
+		cq_entry.len = tx_entry->op_hdr.size;
+		cq_entry.buf = tx_entry->write.msg.msg_iov[0].iov_base;
+		cq_entry.data = tx_entry->op_hdr.data;
+		break;
+
+	case RXD_TX_READ_REQ:
+		cq_entry.flags = (FI_TRANSMIT | FI_RMA | FI_READ);
+		cq_entry.op_context = tx_entry->read_req.msg.context;
+		cq_entry.len = tx_entry->op_hdr.size;
+		cq_entry.buf = tx_entry->read_req.msg.msg_iov[0].iov_base;
+		cq_entry.data = tx_entry->op_hdr.data;
+		break;
+
+	case RXD_TX_READ_RSP:
+		return;
 
 	default:
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type\n");
@@ -650,10 +678,23 @@ void rxd_ep_handle_data_msg(struct rxd_ep *ep, struct rxd_peer *peer,
 
 	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "reporting RX completion event\n");
 	rxd_report_rx_comp(ep->rx_cq, rx_entry);
-	if (rx_entry->op_hdr.op == ofi_op_msg) {
+
+	switch(rx_entry->op_hdr.op) {
+	case ofi_op_msg:
 		freestack_push(ep->recv_fs, rx_entry->recv);
-	} else {
+		break;
+
+	case ofi_op_tagged:
 		freestack_push(ep->trecv_fs, rx_entry->trecv);
+		break;
+
+	case ofi_op_read_rsp:
+		rxd_cq_report_tx_comp(ep->tx_cq, rx_entry->read_rsp.tx_entry);
+		rxd_tx_entry_done(ep, rx_entry->read_rsp.tx_entry);
+		break;
+
+	default:
+		break;
 	}
 	rxd_rx_entry_release(ep, rx_entry);
 }
@@ -787,6 +828,7 @@ void rxd_handle_data(struct rxd_ep *ep, struct rxd_peer *peer,
 {
 	int ret;
 	struct rxd_rx_entry *rx_entry;
+	struct rxd_tx_entry *tx_entry;
 	struct rxd_pkt_data *pkt_data = (struct rxd_pkt_data *) ctrl;
 	uint16_t win_sz;
 	uint64_t curr_stamp;
@@ -841,8 +883,19 @@ void rxd_handle_data(struct rxd_ep *ep, struct rxd_peer *peer,
 				     pkt_data->data, rx_buf);
 		break;
 
-	case ofi_op_read:
 	case ofi_op_write:
+		rxd_ep_handle_data_msg(ep, peer, rx_entry, rx_entry->write.iov,
+				       rx_entry->op_hdr.iov_count, ctrl,
+				       pkt_data->data, rx_buf);
+		break;
+
+	case ofi_op_read_rsp:
+		tx_entry = rx_entry->read_rsp.tx_entry;
+		rxd_ep_handle_data_msg(ep, peer, rx_entry, tx_entry->read_req.dst_iov,
+				       tx_entry->read_req.msg.iov_count, ctrl,
+				       pkt_data->data, rx_buf);
+		break;
+
 	case ofi_op_atomic:
 	default:
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type\n");
@@ -859,12 +912,34 @@ out:
 	rxd_ep_unlock_if_required(ep);
 }
 
-int rxd_process_start_data(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry,
-			    struct rxd_peer *peer, struct ofi_ctrl_hdr *ctrl,
-			    struct fi_cq_msg_entry *comp,
-			    struct rxd_rx_buf *rx_buf)
+void rxd_ep_handle_read_req(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
+			    struct rxd_peer *peer)
 {
+	int ret;
+
+	dlist_init(&tx_entry->pkt_list);
+	tx_entry->op_type = RXD_TX_READ_RSP;
+	ret = rxd_ep_post_start_msg(ep, peer, ofi_op_read_rsp, tx_entry);
+	if (ret)
+		goto err;
+
+	dlist_insert_tail(&tx_entry->entry, &ep->tx_entry_list);
+	return;
+err:
+	rxd_tx_entry_release(ep, tx_entry);
+	return;
+}
+
+int rxd_process_start_data(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry,
+			   struct rxd_peer *peer, struct ofi_ctrl_hdr *ctrl,
+			   struct fi_cq_msg_entry *comp,
+			   struct rxd_rx_buf *rx_buf)
+{
+	uint64_t idx;
+	int i, offset, ret;
+	struct ofi_rma_iov *rma_iov;
 	struct rxd_pkt_data_start *pkt_start;
+	struct rxd_tx_entry *tx_entry;
 	pkt_start = (struct rxd_pkt_data_start *) ctrl;
 
 	switch (rx_entry->op_hdr.op) {
@@ -906,8 +981,69 @@ int rxd_process_start_data(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry,
 				     pkt_start->data, rx_buf);
 		break;
 
-	case ofi_op_read:
 	case ofi_op_write:
+		rma_iov = (struct ofi_rma_iov *) pkt_start->data;
+		for (i = 0; i < rx_entry->op_hdr.iov_count; i++) {
+			ret = rxd_mr_verify(ep->domain,
+					    rma_iov[i].len, &rma_iov[i].addr,
+					    rma_iov[i].key, FI_WRITE);
+			if (ret) {
+				/* todo: handle invalid key case */
+				FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid key/access permissions\n");
+				return -FI_EACCES;
+			}
+
+			rx_entry->write.iov[i].iov_base = (void *) rma_iov[i].addr;
+			rx_entry->write.iov[i].iov_len = rma_iov[i].len;
+		}
+
+		offset = sizeof(struct ofi_rma_iov) * rx_entry->op_hdr.iov_count;
+		ctrl->seg_size -= offset;
+		rxd_ep_handle_data_msg(ep, peer, rx_entry, rx_entry->write.iov,
+				       rx_entry->op_hdr.iov_count, ctrl,
+				       pkt_start->data + offset, rx_buf);
+		break;
+
+	case ofi_op_read_req:
+		rma_iov = (struct ofi_rma_iov *) pkt_start->data;
+		tx_entry = rxd_tx_entry_acquire_fast(ep, peer);
+		if (!tx_entry) {
+			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "no free tx-entry\n");
+			return -FI_ENOMEM;
+		}
+
+		tx_entry->peer = rx_entry->peer;
+		tx_entry->read_rsp.iov_count = rx_entry->op_hdr.iov_count;
+		for (i = 0; i < rx_entry->op_hdr.iov_count; i++) {
+			ret = rxd_mr_verify(ep->domain,
+					    rma_iov[i].len, &rma_iov[i].addr,
+					    rma_iov[i].key, FI_READ);
+			if (ret) {
+				/* todo: handle invalid key case */
+				FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid key/access permissions\n");
+				return -FI_EACCES;
+			}
+
+			tx_entry->read_rsp.src_iov[i].iov_base = (void *) rma_iov[i].addr;
+			tx_entry->read_rsp.src_iov[i].iov_len = rma_iov[i].len;
+		}
+		tx_entry->read_rsp.peer_msg_id = ctrl->msg_id;
+		rxd_ep_handle_read_req(ep, tx_entry, peer);
+		rxd_rx_entry_release(ep, rx_entry);
+		break;
+
+	case ofi_op_read_rsp:
+		idx = rx_entry->op_hdr.peer_id & RXD_TX_IDX_BITS;
+		tx_entry = &ep->tx_entry_fs->buf[idx];
+		if (tx_entry->msg_id != rx_entry->op_hdr.peer_id)
+			return -FI_ENOMEM;
+
+		rx_entry->read_rsp.tx_entry = tx_entry;
+		rxd_ep_handle_data_msg(ep, peer, rx_entry, tx_entry->read_req.dst_iov,
+				       tx_entry->read_req.msg.iov_count, ctrl,
+				       pkt_start->data, rx_buf);
+		break;
+
 	case ofi_op_atomic:
 	default:
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type\n");
@@ -917,9 +1053,9 @@ int rxd_process_start_data(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry,
 }
 
 void rxd_handle_start_data(struct rxd_ep *ep, struct rxd_peer *peer,
-			    struct ofi_ctrl_hdr *ctrl,
-			    struct fi_cq_msg_entry *comp,
-			    struct rxd_rx_buf *rx_buf)
+			   struct ofi_ctrl_hdr *ctrl,
+			   struct fi_cq_msg_entry *comp,
+			   struct rxd_rx_buf *rx_buf)
 {
 	int ret;
 	struct rxd_rx_entry *rx_entry;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -1125,7 +1125,7 @@ static int rxd_cq_close(struct fid *fid)
 	ret = ofi_cq_cleanup(&cq->util_cq);
 	if (ret)
 		return ret;
-
+	util_buf_pool_destroy(cq->unexp_pool);
 	free(cq);
 	return 0;
 }

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -367,11 +367,51 @@ struct rxd_pkt_meta *rxd_tx_pkt_acquire(struct rxd_ep *ep)
 	return pkt_meta;
 }
 
+static uint64_t rxd_ep_copy_data(struct rxd_tx_entry *tx_entry,
+				 struct rxd_pkt_data *pkt, uint64_t data_sz)
+{
+	uint64_t done;
+	switch(tx_entry->op_hdr.op) {
+	case ofi_op_msg:
+		done = rxd_ep_copy_iov_buf(tx_entry->msg.msg_iov,
+					   tx_entry->msg.msg.iov_count,
+					   pkt->data, data_sz, tx_entry->done,
+					   RXD_COPY_IOV_TO_BUF);
+		break;
+
+	case ofi_op_tagged:
+		done = rxd_ep_copy_iov_buf(tx_entry->tmsg.msg_iov,
+					   tx_entry->tmsg.tmsg.iov_count,
+					   pkt->data, data_sz, tx_entry->done,
+					   RXD_COPY_IOV_TO_BUF);
+		break;
+
+	case ofi_op_write:
+		done = rxd_ep_copy_iov_buf(tx_entry->write.src_iov,
+					   tx_entry->write.msg.iov_count,
+					   pkt->data, data_sz, tx_entry->done,
+					   RXD_COPY_IOV_TO_BUF);
+		break;
+
+	case ofi_op_read_rsp:
+		done = rxd_ep_copy_iov_buf(tx_entry->read_rsp.src_iov,
+					   tx_entry->read_rsp.iov_count,
+					   pkt->data, data_sz, tx_entry->done,
+					   RXD_COPY_IOV_TO_BUF);
+		break;
+
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op-type\n",
+			tx_entry->op_hdr.op);
+		done = 0;
+	}
+	return done;
+}
+
 ssize_t rxd_ep_post_data_msg(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
 {
 	int ret;
-	uint64_t data_sz;
-	size_t done;
+	uint64_t data_sz, done;
 	struct rxd_pkt_meta *pkt_meta;
 	struct rxd_pkt_data *pkt;
 	struct rxd_peer *peer;
@@ -386,17 +426,7 @@ ssize_t rxd_ep_post_data_msg(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
 
 	rxd_init_ctrl_hdr(&pkt->ctrl, ofi_ctrl_data, data_sz, tx_entry->nxt_seg_no,
 			   tx_entry->msg_id, tx_entry->rx_key, peer->conn_data);
-
-	if (tx_entry->op_hdr.op == ofi_op_msg)
-		done = rxd_ep_copy_iov_buf(tx_entry->msg.msg_iov,
-					   tx_entry->msg.msg.iov_count,
-					   pkt->data, data_sz, tx_entry->done,
-					   RXD_COPY_IOV_TO_BUF);
-	else
-		done = rxd_ep_copy_iov_buf(tx_entry->tmsg.msg_iov,
-					   tx_entry->tmsg.tmsg.iov_count,
-					   pkt->data, data_sz, tx_entry->done,
-					   RXD_COPY_IOV_TO_BUF);
+	done = rxd_ep_copy_data(tx_entry, pkt, data_sz);
 
 	pkt_meta->tx_entry = tx_entry;
 	pkt_meta->type = (tx_entry->op_hdr.size == tx_entry->done + done) ?
@@ -476,9 +506,13 @@ int rxd_progress_tx(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
 	switch (tx_entry->op_hdr.op) {
 	case ofi_op_msg:
 	case ofi_op_tagged:
+	case ofi_op_write:
+	case ofi_op_read_rsp:
 		ret = rxd_ep_post_data_msg(ep, tx_entry);
 		break;
+
 	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid pkt type\n");
 		break;
 	}
 	return ret;
@@ -660,8 +694,101 @@ err:
 
 #define RXD_TX_ENTRY_ID(ep, tx_entry) (tx_entry - &ep->tx_entry_fs->buf[0])
 
+void rxd_ep_init_start_hdr(struct rxd_ep *ep, struct rxd_peer *peer,
+			   uint8_t op, struct rxd_tx_entry *tx_entry,
+			   struct rxd_pkt_data_start *pkt, uint32_t flags,
+			   uint64_t *msg_sz, uint64_t *data_sz)
+{
+	size_t curr_offset, i, iov_sz;
+	struct ofi_rma_iov rma_iov;
+
+	switch(op) {
+	case ofi_op_msg:
+		*msg_sz = rxd_get_msg_len(tx_entry->msg.msg_iov, tx_entry->msg.msg.iov_count);
+		*data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), *msg_sz);
+		rxd_init_op_hdr(&pkt->op, tx_entry->msg.msg.data, *msg_sz, 0, op, 0, flags);
+		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->msg.msg_iov,
+						     tx_entry->msg.msg.iov_count,
+						     pkt->data, *data_sz, 0, RXD_COPY_IOV_TO_BUF);
+		break;
+
+	case ofi_op_tagged:
+		*msg_sz = rxd_get_msg_len(tx_entry->tmsg.msg_iov, tx_entry->tmsg.tmsg.iov_count);
+		*data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), *msg_sz);
+		rxd_init_op_hdr(&pkt->op, tx_entry->tmsg.tmsg.data, *msg_sz, 0, op,
+				 tx_entry->tmsg.tmsg.tag, flags);
+		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->tmsg.msg_iov,
+						     tx_entry->tmsg.tmsg.iov_count,
+						     pkt->data, *data_sz, 0, RXD_COPY_IOV_TO_BUF);
+		break;
+
+	case ofi_op_write:
+		*msg_sz = rxd_get_msg_len(tx_entry->write.msg.msg_iov, tx_entry->write.msg.iov_count);
+		iov_sz = sizeof(struct ofi_rma_iov) * tx_entry->write.msg.rma_iov_count;
+		*data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), *msg_sz);
+		*data_sz -= iov_sz;
+
+		rxd_init_op_hdr(&pkt->op, tx_entry->write.msg.data, *msg_sz, 0, op, 0, flags);
+		pkt->op.iov_count = tx_entry->write.msg.rma_iov_count;
+
+		curr_offset = 0;
+		for (i = 0; i < pkt->op.iov_count; i++) {
+			rma_iov.addr = tx_entry->write.dst_iov[i].addr;
+			rma_iov.len = tx_entry->write.dst_iov[i].len;
+			rma_iov.key = tx_entry->write.dst_iov[i].key;
+			memcpy(pkt->data + curr_offset, &rma_iov, sizeof(struct ofi_rma_iov));
+			curr_offset += sizeof(struct ofi_rma_iov);
+		}
+		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->write.msg.msg_iov,
+						     tx_entry->write.msg.iov_count,
+						     pkt->data + curr_offset, *data_sz, 0,
+						     RXD_COPY_IOV_TO_BUF);
+		*data_sz = tx_entry->done + iov_sz;
+		break;
+
+	case ofi_op_read_req:
+		*msg_sz = rxd_get_msg_len(tx_entry->read_req.msg.msg_iov,
+					  tx_entry->read_req.msg.iov_count);
+
+		rxd_init_op_hdr(&pkt->op, tx_entry->read_req.msg.data, *msg_sz,
+				0, op, 0, flags);
+		pkt->op.iov_count = tx_entry->read_req.msg.rma_iov_count;
+
+		tx_entry->done = 0;
+		curr_offset = 0;
+		*data_sz = 0;
+		for (i = 0; i < pkt->op.iov_count; i++) {
+			rma_iov.addr = tx_entry->read_req.src_iov[i].addr;
+			rma_iov.len = tx_entry->read_req.src_iov[i].len;
+			rma_iov.key = tx_entry->read_req.src_iov[i].key;
+			memcpy(pkt->data + curr_offset, &rma_iov, sizeof(struct ofi_rma_iov));
+			curr_offset += sizeof(struct ofi_rma_iov);
+		}
+		*data_sz += curr_offset;
+		assert(*data_sz <= RXD_MAX_STRT_DATA_PKT_SZ(ep));
+		break;
+
+	case ofi_op_read_rsp:
+		*msg_sz = rxd_get_msg_len(tx_entry->read_rsp.src_iov,
+					  tx_entry->read_rsp.iov_count);
+		*data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), *msg_sz);
+
+		rxd_init_op_hdr(&pkt->op, 0, *msg_sz, 0, op, 0, flags);
+		pkt->op.peer_id = tx_entry->read_rsp.peer_msg_id;
+
+		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->read_rsp.src_iov,
+						     tx_entry->read_rsp.iov_count,
+						     pkt->data, *data_sz, 0,
+						     RXD_COPY_IOV_TO_BUF);
+		break;
+
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op-type\n", op);
+	}
+}
+
 ssize_t rxd_ep_post_start_msg(struct rxd_ep *ep, struct rxd_peer *peer,
-			       uint8_t op, struct rxd_tx_entry *tx_entry)
+			      uint8_t op, struct rxd_tx_entry *tx_entry)
 {
 	ssize_t ret;
 	uint32_t flags;
@@ -678,25 +805,7 @@ ssize_t rxd_ep_post_start_msg(struct rxd_ep *ep, struct rxd_peer *peer,
 	flags = rxd_prepare_tx_flags(tx_entry->flags);
 	tx_entry->msg_id = RXD_TX_ID(peer->nxt_msg_id, RXD_TX_ENTRY_ID(ep, tx_entry));
 
-	if (op == ofi_op_msg) {
-		msg_sz = rxd_get_msg_len(tx_entry->msg.msg_iov, tx_entry->msg.msg.iov_count);
-		data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), msg_sz);
-		rxd_init_op_hdr(&pkt->op, tx_entry->msg.msg.data, msg_sz, 0, op, 0, flags);
-		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->msg.msg_iov,
-						     tx_entry->msg.msg.iov_count,
-						     pkt->data, data_sz, 0, RXD_COPY_IOV_TO_BUF);
-	} else {
-		msg_sz = rxd_get_msg_len(tx_entry->tmsg.msg_iov, tx_entry->tmsg.tmsg.iov_count);
-		data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), msg_sz);
-		rxd_init_op_hdr(&pkt->op, tx_entry->tmsg.tmsg.data, msg_sz, 0, op,
-				 tx_entry->tmsg.tmsg.tag,flags);
-		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->tmsg.msg_iov,
-						     tx_entry->tmsg.tmsg.iov_count,
-						     pkt->data, data_sz, 0, RXD_COPY_IOV_TO_BUF);
-		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "sent start %p, tag: %p, len: %d\n",
-		       pkt->ctrl.msg_id, tx_entry->tmsg.tmsg.tag, msg_sz);
-	}
-
+	rxd_ep_init_start_hdr(ep, peer, op, tx_entry, pkt, flags, &msg_sz, &data_sz);
 	rxd_init_ctrl_hdr(&pkt->ctrl, ofi_ctrl_start_data, data_sz, 0,
 			   tx_entry->msg_id, peer->conn_data, peer->conn_data);
 	tx_entry->nxt_seg_no = 1;
@@ -761,7 +870,7 @@ out:
 }
 
 ssize_t rxd_ep_post_conn_msg(struct rxd_ep *ep, struct rxd_peer *peer,
-			      fi_addr_t addr)
+			     fi_addr_t addr)
 {
 	ssize_t ret;
 	size_t addrlen;
@@ -818,12 +927,13 @@ err:
 	return ret;
 }
 
-struct rxd_tx_entry *rxd_tx_entry_acquire(struct rxd_ep *ep, struct rxd_peer *peer)
+struct rxd_tx_entry *rxd_tx_entry_acquire_fast(struct rxd_ep *ep, struct rxd_peer *peer)
 {
 	struct rxd_tx_entry *tx_entry;
-	if (freestack_isempty(ep->tx_entry_fs) ||
-	    peer->num_msg_out == RXD_MAX_OUT_TX_MSG)
+	if (freestack_isempty(ep->tx_entry_fs)) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "no-more tx entries\n");
 		return NULL;
+	}
 
 	peer->num_msg_out++;
 	tx_entry = freestack_pop(ep->tx_entry_fs);
@@ -831,6 +941,12 @@ struct rxd_tx_entry *rxd_tx_entry_acquire(struct rxd_ep *ep, struct rxd_peer *pe
 	tx_entry->is_waiting = 0;
 	dlist_init(&tx_entry->entry);
 	return tx_entry;
+}
+
+struct rxd_tx_entry *rxd_tx_entry_acquire(struct rxd_ep *ep, struct rxd_peer *peer)
+{
+	return (peer->num_msg_out == RXD_MAX_OUT_TX_MSG) ? NULL :
+		rxd_tx_entry_acquire_fast(ep, peer);
 }
 
 void rxd_tx_entry_release(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
@@ -843,8 +959,16 @@ void rxd_tx_entry_release(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
 	freestack_push(ep->tx_entry_fs, tx_entry);
 }
 
-static inline void rxd_copy_iov(const struct iovec *src_iov,
-				 struct iovec *dst_iov, size_t iov_count)
+void rxd_ep_copy_msg_iov(const struct iovec *src_iov,
+			 struct iovec *dst_iov, size_t iov_count)
+{
+	size_t i;
+	for (i = 0; i < iov_count; i++)
+		dst_iov[i] = src_iov[i];
+}
+
+void rxd_ep_copy_rma_iov(const struct fi_rma_iov *src_iov,
+			 struct fi_rma_iov *dst_iov, size_t iov_count)
 {
 	size_t i;
 	for (i = 0; i < iov_count; i++)
@@ -882,7 +1006,7 @@ static ssize_t rxd_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	tx_entry->msg.msg = *msg;
 	tx_entry->flags = flags;
 	tx_entry->peer = peer_addr;
-	rxd_copy_iov(msg->msg_iov, &tx_entry->msg.msg_iov[0], msg->iov_count);
+	rxd_ep_copy_msg_iov(msg->msg_iov, &tx_entry->msg.msg_iov[0], msg->iov_count);
 
 	ret = rxd_ep_post_start_msg(rxd_ep, peer, ofi_op_msg, tx_entry);
 	if (ret)
@@ -1231,7 +1355,7 @@ ssize_t rxd_ep_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 	tx_entry->tmsg.tmsg = *msg;
 	tx_entry->flags = flags;
 	tx_entry->peer = peer_addr;
-	rxd_copy_iov(msg->msg_iov, &tx_entry->tmsg.msg_iov[0], msg->iov_count);
+	rxd_ep_copy_msg_iov(msg->msg_iov, &tx_entry->tmsg.msg_iov[0], msg->iov_count);
 
 	ret = rxd_ep_post_start_msg(rxd_ep, peer, ofi_op_tagged, tx_entry);
 	if (ret)
@@ -1669,6 +1793,7 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 	rxd_ep->ep.ops = &rxd_ops_ep;
 	rxd_ep->ep.msg = &rxd_ops_msg;
 	rxd_ep->ep.tagged = &rxd_ops_tagged;
+	rxd_ep->ep.rma = &rxd_ops_rma;
 
 	dlist_init(&rxd_ep->tx_entry_list);
 	dlist_init(&rxd_ep->rx_entry_list);

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <fi_mem.h>
+#include "rxd.h"
+
+ssize_t	rxd_ep_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		       uint64_t flags)
+{
+	ssize_t ret;
+	uint64_t peer_addr;
+	struct rxd_ep *rxd_ep;
+	struct rxd_peer *peer;
+	struct rxd_tx_entry *tx_entry;
+	rxd_ep = container_of(ep, struct rxd_ep, ep);
+
+	peer_addr = rxd_av_get_dg_addr(rxd_ep->av, msg->addr);
+	peer = rxd_ep_getpeer_info(rxd_ep, peer_addr);
+
+#if ENABLE_DEBUG
+	if (msg->iov_count > RXD_IOV_LIMIT ||
+	    msg->rma_iov_count > RXD_IOV_LIMIT)
+		return -FI_EINVAL;
+#endif
+
+	rxd_ep_lock_if_required(rxd_ep);
+	if (!peer->addr_published) {
+		ret = rxd_ep_post_conn_msg(rxd_ep, peer, peer_addr);
+		ret = (ret) ? ret : -FI_EAGAIN;
+		goto out;
+	}
+
+	tx_entry = rxd_tx_entry_acquire(rxd_ep, peer);
+	if (!tx_entry) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	dlist_init(&tx_entry->pkt_list);
+	tx_entry->op_type = RXD_TX_READ_REQ;
+	tx_entry->read_req.msg = *msg;
+	tx_entry->flags = flags;
+	tx_entry->peer = peer_addr;
+	rxd_ep_copy_msg_iov(msg->msg_iov,
+			    &tx_entry->read_req.dst_iov[0], msg->iov_count);
+	rxd_ep_copy_rma_iov(msg->rma_iov,
+			    &tx_entry->read_req.src_iov[0], msg->rma_iov_count);
+	ret = rxd_ep_post_start_msg(rxd_ep, peer, ofi_op_read_req, tx_entry);
+	if (ret)
+		goto err;
+
+	dlist_insert_tail(&tx_entry->entry, &rxd_ep->tx_entry_list);
+out:
+	rxd_ep_unlock_if_required(rxd_ep);
+	return ret;
+err:
+	rxd_tx_entry_release(rxd_ep, tx_entry);
+	goto out;
+}
+
+static ssize_t rxd_ep_read(struct fid_ep *ep, void *buf, size_t len,
+				 void *desc, fi_addr_t src_addr, uint64_t addr,
+				 uint64_t key, void *context)
+{
+	struct fi_msg_rma msg;
+	struct iovec msg_iov;
+	struct fi_rma_iov rma_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+
+	rma_iov.addr = addr;
+	rma_iov.key = key;
+	rma_iov.len = len;
+	msg.rma_iov_count = 1;
+	msg.rma_iov = &rma_iov;
+
+	msg.addr = src_addr;
+	msg.context = context;
+
+	return rxd_ep_readmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+static ssize_t rxd_ep_readv(struct fid_ep *ep, const struct iovec *iov,
+				void **desc, size_t count,
+				fi_addr_t src_addr, uint64_t addr, uint64_t key,
+				void *context)
+{
+	size_t len, i;
+	struct fi_msg_rma msg;
+	struct fi_rma_iov rma_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = iov;
+	msg.desc = desc;
+	msg.iov_count = count;
+	msg.rma_iov_count = 1;
+
+	rma_iov.addr = addr;
+	rma_iov.key = key;
+
+#if ENABLE_DEBUG
+	if (count > RXD_IOV_LIMIT)
+		return -FI_EINVAL;
+#endif
+
+	for (i = 0, len = 0; i < count; i++)
+		len += iov[i].iov_len;
+	rma_iov.len = len;
+
+	msg.rma_iov = &rma_iov;
+	msg.addr = src_addr;
+	msg.context = context;
+
+	return rxd_ep_readmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+ssize_t	rxd_ep_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+			uint64_t flags)
+{
+	ssize_t ret;
+	uint64_t peer_addr;
+	struct rxd_ep *rxd_ep;
+	struct rxd_peer *peer;
+	struct rxd_tx_entry *tx_entry;
+	rxd_ep = container_of(ep, struct rxd_ep, ep);
+
+	peer_addr = rxd_av_get_dg_addr(rxd_ep->av, msg->addr);
+	peer = rxd_ep_getpeer_info(rxd_ep, peer_addr);
+
+#if ENABLE_DEBUG
+	if (msg->iov_count > RXD_IOV_LIMIT ||
+	    msg->rma_iov_count > RXD_IOV_LIMIT)
+		return -FI_EINVAL;
+#endif
+
+	rxd_ep_lock_if_required(rxd_ep);
+	if (!peer->addr_published) {
+		ret = rxd_ep_post_conn_msg(rxd_ep, peer, peer_addr);
+		ret = (ret) ? ret : -FI_EAGAIN;
+		goto out;
+	}
+
+	tx_entry = rxd_tx_entry_acquire(rxd_ep, peer);
+	if (!tx_entry) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	dlist_init(&tx_entry->pkt_list);
+	tx_entry->op_type = RXD_TX_WRITE;
+	tx_entry->write.msg = *msg;
+	tx_entry->flags = flags;
+	tx_entry->peer = peer_addr;
+	rxd_ep_copy_msg_iov(msg->msg_iov, &tx_entry->write.src_iov[0], msg->iov_count);
+	rxd_ep_copy_rma_iov(msg->rma_iov, &tx_entry->write.dst_iov[0], msg->rma_iov_count);
+
+	ret = rxd_ep_post_start_msg(rxd_ep, peer, ofi_op_write, tx_entry);
+	if (ret)
+		goto err;
+
+	dlist_insert_tail(&tx_entry->entry, &rxd_ep->tx_entry_list);
+out:
+	rxd_ep_unlock_if_required(rxd_ep);
+	return ret;
+err:
+	rxd_tx_entry_release(rxd_ep, tx_entry);
+	goto out;
+}
+
+static ssize_t rxd_ep_write(struct fid_ep *ep, const void *buf,
+			    size_t len, void *desc, fi_addr_t dest_addr,
+			    uint64_t addr, uint64_t key, void *context)
+{
+	struct fi_msg_rma msg;
+	struct iovec msg_iov;
+	struct fi_rma_iov rma_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+
+	rma_iov.addr = addr;
+	rma_iov.key = key;
+	rma_iov.len = len;
+
+	msg.rma_iov_count = 1;
+	msg.rma_iov = &rma_iov;
+
+	msg.addr = dest_addr;
+	msg.context = context;
+
+	return rxd_ep_writemsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+static ssize_t rxd_ep_writev(struct fid_ep *ep, const struct iovec *iov,
+			     void **desc, size_t count, fi_addr_t dest_addr,
+			     uint64_t addr, uint64_t key, void *context)
+{
+	int i;
+	size_t len;
+	struct fi_msg_rma msg;
+	struct fi_rma_iov rma_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = iov;
+	msg.desc = desc;
+	msg.iov_count = count;
+	msg.rma_iov_count = 1;
+
+#if ENABLE_DEBUG
+	if (count > RXD_IOV_LIMIT)
+		return -FI_EINVAL;
+#endif
+
+	for (i = 0, len = 0; i < count; i++)
+		len += iov[i].iov_len;
+
+	rma_iov.addr = addr;
+	rma_iov.key = key;
+	rma_iov.len = len;
+
+	msg.rma_iov = &rma_iov;
+	msg.context = context;
+	msg.addr = dest_addr;
+
+	return rxd_ep_writemsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+static ssize_t rxd_ep_writedata(struct fid_ep *ep, const void *buf,
+				size_t len, void *desc, uint64_t data,
+				fi_addr_t dest_addr, uint64_t addr,
+				uint64_t key, void *context)
+{
+	struct fi_msg_rma msg;
+	struct iovec msg_iov;
+	struct fi_rma_iov rma_iov;
+
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.rma_iov_count = 1;
+
+	rma_iov.addr = addr;
+	rma_iov.key = key;
+	rma_iov.len = len;
+
+	msg.rma_iov = &rma_iov;
+	msg.msg_iov = &msg_iov;
+
+	msg.addr = dest_addr;
+	msg.context = context;
+	msg.data = data;
+
+	return rxd_ep_writemsg(ep, &msg, FI_REMOTE_CQ_DATA |
+					RXD_USE_OP_FLAGS);
+}
+
+static ssize_t rxd_ep_inject(struct fid_ep *ep, const void *buf,
+			     size_t len, fi_addr_t dest_addr, uint64_t addr,
+			     uint64_t key)
+{
+	struct fi_msg_rma msg;
+	struct iovec msg_iov;
+	struct fi_rma_iov rma_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+	msg.iov_count = 1;
+	msg.rma_iov_count = 1;
+
+	rma_iov.addr = addr;
+	rma_iov.key = key;
+	rma_iov.len = len;
+
+	msg.rma_iov = &rma_iov;
+	msg.msg_iov = &msg_iov;
+	msg.addr = dest_addr;
+
+	return rxd_ep_writemsg(ep, &msg, FI_INJECT |
+				    RXD_NO_COMPLETION | RXD_USE_OP_FLAGS);
+}
+
+static ssize_t rxd_ep_injectdata(struct fid_ep *ep, const void *buf,
+				 size_t len, uint64_t data,
+				 fi_addr_t dest_addr, uint64_t addr,
+					uint64_t key)
+{
+	struct fi_msg_rma msg;
+	struct iovec msg_iov;
+	struct fi_rma_iov rma_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+	msg.iov_count = 1;
+	msg.rma_iov_count = 1;
+
+	rma_iov.addr = addr;
+	rma_iov.key = key;
+	rma_iov.len = len;
+
+	msg.rma_iov = &rma_iov;
+	msg.msg_iov = &msg_iov;
+	msg.addr = dest_addr;
+	msg.data = data;
+	return rxd_ep_writemsg(ep, &msg, FI_INJECT | FI_REMOTE_CQ_DATA |
+		RXD_NO_COMPLETION | RXD_USE_OP_FLAGS);
+}
+
+struct fi_ops_rma rxd_ops_rma = {
+	.size = sizeof (struct fi_ops_rma),
+	.read = rxd_ep_read,
+	.readv = rxd_ep_readv,
+	.readmsg = rxd_ep_readmsg,
+	.write = rxd_ep_write,
+	.writev = rxd_ep_writev,
+	.writemsg = rxd_ep_writemsg,
+	.inject = rxd_ep_inject,
+	.writedata = rxd_ep_writedata,
+	.injectdata = rxd_ep_injectdata,
+};

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -942,6 +942,7 @@ int sock_verify_info(struct fi_info *hints);
 int sock_verify_fabric_attr(struct fi_fabric_attr *attr);
 int sock_verify_domain_attr(struct fi_domain_attr *attr);
 
+size_t sock_get_tx_size(size_t size);
 int sock_rdm_verify_ep_attr(struct fi_ep_attr *ep_attr, struct fi_tx_attr *tx_attr,
 			    struct fi_rx_attr *rx_attr);
 int sock_dgram_verify_ep_attr(struct fi_ep_attr *ep_attr, struct fi_tx_attr *tx_attr,

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -61,7 +61,7 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr,
 
 	rx_ctx->ctx.fid.fclass = FI_CLASS_RX_CTX;
 	rx_ctx->ctx.fid.context = context;
-	rx_ctx->num_left = attr->size;
+	rx_ctx->num_left = sock_get_tx_size(attr->size);
 	rx_ctx->attr = *attr;
 	rx_ctx->use_shared = use_shared;
 	return rx_ctx;

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -109,7 +109,8 @@ static int sock_dgram_verify_rx_attr(const struct fi_rx_attr *attr)
 	if (attr->total_buffered_recv > sock_dgram_rx_attr.total_buffered_recv)
 		return -FI_ENODATA;
 
-	if (attr->size > sock_dgram_rx_attr.size)
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_dgram_rx_attr.size))
 		return -FI_ENODATA;
 
 	if (attr->iov_limit > sock_dgram_rx_attr.iov_limit)
@@ -132,7 +133,8 @@ static int sock_dgram_verify_tx_attr(const struct fi_tx_attr *attr)
 	if (attr->inject_size > sock_dgram_tx_attr.inject_size)
 		return -FI_ENODATA;
 
-	if (attr->size > sock_dgram_tx_attr.size)
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_dgram_tx_attr.size))
 		return -FI_ENODATA;
 
 	if (attr->iov_limit > sock_dgram_tx_attr.iov_limit)
@@ -203,7 +205,9 @@ int sock_dgram_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		return -FI_ENOMEM;
 
 	*(*info)->tx_attr = sock_dgram_tx_attr;
+	(*info)->tx_attr->size = sock_get_tx_size(sock_dgram_tx_attr.size);
 	*(*info)->rx_attr = sock_dgram_rx_attr;
+	(*info)->rx_attr->size = sock_get_tx_size(sock_dgram_rx_attr.size);
 	*(*info)->ep_attr = sock_dgram_ep_attr;
 
 	if (hints && hints->ep_attr) {

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -111,7 +111,8 @@ static int sock_msg_verify_rx_attr(const struct fi_rx_attr *attr)
 	if (attr->total_buffered_recv > sock_msg_rx_attr.total_buffered_recv)
 		return -FI_ENODATA;
 
-	if (attr->size > sock_msg_rx_attr.size)
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_msg_rx_attr.size))
 		return -FI_ENODATA;
 
 	if (attr->iov_limit > sock_msg_rx_attr.iov_limit)
@@ -134,7 +135,8 @@ static int sock_msg_verify_tx_attr(const struct fi_tx_attr *attr)
 	if (attr->inject_size > sock_msg_tx_attr.inject_size)
 		return -FI_ENODATA;
 
-	if (attr->size > sock_msg_tx_attr.size)
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_msg_tx_attr.size))
 		return -FI_ENODATA;
 
 	if (attr->iov_limit > sock_msg_tx_attr.iov_limit)
@@ -204,7 +206,9 @@ int sock_msg_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		return -FI_ENOMEM;
 
 	*(*info)->tx_attr = sock_msg_tx_attr;
+	(*info)->tx_attr->size = sock_get_tx_size(sock_msg_tx_attr.size);
 	*(*info)->rx_attr = sock_msg_rx_attr;
+	(*info)->rx_attr->size = sock_get_tx_size(sock_msg_rx_attr.size);
 	*(*info)->ep_attr = sock_msg_ep_attr;
 
 	if (hints && hints->ep_attr) {

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -118,7 +118,8 @@ static int sock_rdm_verify_rx_attr(const struct fi_rx_attr *attr)
 		return -FI_ENODATA;
 	}
 
-	if (attr->size > sock_rdm_rx_attr.size) {
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_rdm_rx_attr.size)) {
 		SOCK_LOG_DBG("Rx size too large\n");
 		return -FI_ENODATA;
 	}
@@ -151,7 +152,8 @@ static int sock_rdm_verify_tx_attr(const struct fi_tx_attr *attr)
 		return -FI_ENODATA;
 	}
 
-	if (attr->size > sock_rdm_tx_attr.size) {
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_rdm_tx_attr.size)) {
 		SOCK_LOG_DBG("Tx size too large\n");
 		return -FI_ENODATA;
 	}
@@ -247,7 +249,9 @@ int sock_rdm_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		return -FI_ENOMEM;
 
 	*(*info)->tx_attr = sock_rdm_tx_attr;
+	(*info)->tx_attr->size = sock_get_tx_size(sock_rdm_tx_attr.size);
 	*(*info)->rx_attr = sock_rdm_rx_attr;
+	(*info)->rx_attr->size = sock_get_tx_size(sock_rdm_rx_attr.size);
 	*(*info)->ep_attr = sock_rdm_ep_attr;
 
 	if (hints && hints->ep_attr) {

--- a/prov/sockets/src/sock_wait.c
+++ b/prov/sockets/src/sock_wait.c
@@ -50,7 +50,9 @@ enum {
 
 int sock_wait_get_obj(struct fid_wait *fid, void *arg)
 {
+#ifndef _WIN32 /* there is no support of wait objects on windows */
 	struct fi_mutex_cond mut_cond;
+#endif /* _WIN32 */
 	struct sock_wait *wait;
 
 	wait = container_of(fid, struct sock_wait, wait_fid.fid);
@@ -58,6 +60,7 @@ int sock_wait_get_obj(struct fid_wait *fid, void *arg)
 		return -FI_ENOSYS;
 
 	switch (wait->type) {
+#ifndef _WIN32
 	case FI_WAIT_FD:
 		memcpy(arg, &wait->wobj.fd[WAIT_READ_FD], sizeof(int));
 		break;
@@ -67,7 +70,7 @@ int sock_wait_get_obj(struct fid_wait *fid, void *arg)
 		mut_cond.cond  = &wait->wobj.mutex_cond.cond;
 		memcpy(arg, &mut_cond, sizeof(mut_cond));
 		break;
-
+#endif /* _WIN32 */
 	default:
 		SOCK_LOG_ERROR("Invalid wait obj type\n");
 		return -FI_EINVAL;

--- a/prov/udp/src/udpx_cq.c
+++ b/prov/udp/src/udpx_cq.c
@@ -35,6 +35,27 @@
 
 #include "udpx.h"
 
+static int udpx_cq_close(struct fid *fid)
+{
+	int ret;
+	struct util_cq *cq;
+
+	cq = container_of(fid, struct util_cq, cq_fid.fid);
+	ret = ofi_cq_cleanup(cq);
+	if (ret)
+		return ret;
+	free(cq);
+	return 0;
+}
+
+static struct fi_ops udpx_cq_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = udpx_cq_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
 int udpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq_fid, void *context)
 {
@@ -53,5 +74,6 @@ int udpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	}
 
 	*cq_fid = &cq->cq_fid;
+	(*cq_fid)->fid.ops = &udpx_cq_fi_ops;
 	return 0;
 }

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -479,7 +479,8 @@ int usdf_endpoint_open(struct fid_domain *domain, struct fi_info *info,
 		struct fid_ep **ep, void *context);
 int usdf_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		 struct fid_av **av_o, void *context);
-
+int usdf_domain_getname(uint32_t version, struct usd_device_attrs *dap,
+			char **name);
 
 /* fi_ops_mr */
 int usdf_reg_mr(struct fid *fid, const void *buf, size_t len,

--- a/prov/usnic/src/usdf_dgram.h
+++ b/prov/usnic/src/usdf_dgram.h
@@ -57,7 +57,8 @@ int usdf_dgram_fill_rx_attr(struct fi_info *hints,
 		struct fi_info *fi, struct usd_device_attrs *dap);
 int usdf_dgram_fill_tx_attr(struct fi_info *hints, struct fi_info *fi,
 		struct usd_device_attrs *dap);
-int usdf_dgram_fill_dom_attr(struct fi_info *hints, struct fi_info *fi);
+int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
+			     struct fi_info *fi, struct usd_device_attrs *dap);
 int usdf_dgram_fill_ep_attr(uint32_t version, struct fi_info *hints,
 		struct fi_info *fi, struct usd_device_attrs *dap);
 

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -344,3 +344,21 @@ fail:
 	}
 	return ret;
 }
+
+int usdf_domain_getname(uint32_t version, struct usd_device_attrs *dap,
+			char **name)
+{
+	int ret = FI_SUCCESS;
+	char *buf = NULL;
+
+	if (FI_VERSION_GE(version, FI_VERSION(1, 4))) {
+		buf = strdup(dap->uda_devname);
+		if (!buf) {
+			ret = -errno;
+			USDF_DBG("strdup failed while creating domain name\n");
+		}
+	}
+
+	*name = buf;
+	return ret;
+}

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -456,12 +456,16 @@ out:
 	return FI_SUCCESS;
 }
 
-int usdf_dgram_fill_dom_attr(struct fi_info *hints, struct fi_info *fi)
+int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
+			     struct fi_info *fi, struct usd_device_attrs *dap)
 {
+	int ret;
 	struct fi_domain_attr defaults;
 
 	defaults = dgram_dflt_domain_attr;
-	defaults.name = strdup("usnic");
+	ret = usdf_domain_getname(version, dap, &defaults.name);
+	if (ret < 0)
+		return -FI_ENODATA;
 
 	if (!hints || !hints->domain_attr)
 		goto out;

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -163,12 +163,16 @@ out:
 	return FI_SUCCESS;
 }
 
-int usdf_msg_fill_dom_attr(struct fi_info *hints, struct fi_info *fi)
+int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
+			   struct fi_info *fi, struct usd_device_attrs *dap)
 {
+	int ret;
 	struct fi_domain_attr defaults;
 
 	defaults = msg_dflt_domain_attr;
-	defaults.name = strdup("usnic");
+	ret = usdf_domain_getname(version, dap, &defaults.name);
+	if (ret < 0)
+		return -FI_ENODATA;
 
 	if (!hints || !hints->domain_attr)
 		goto out;

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -59,6 +59,7 @@
 
 #include "usd.h"
 #include "usdf.h"
+#include "usnic_direct.h"
 #include "usdf_endpoint.h"
 #include "fi_ext_usnic.h"
 #include "usdf_rudp.h"
@@ -166,12 +167,16 @@ out:
 
 }
 
-int usdf_rdm_fill_dom_attr(struct fi_info *hints, struct fi_info *fi)
+int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
+			   struct fi_info *fi, struct usd_device_attrs *dap)
 {
+	int ret;
 	struct fi_domain_attr defaults;
 
 	defaults = rdm_dflt_domain_attr;
-	defaults.name = strdup("usnic");
+	ret = usdf_domain_getname(version, dap, &defaults.name);
+	if (ret < 0)
+		return -FI_ENODATA;
 
 	if (!hints || !hints->domain_attr)
 		goto out;

--- a/prov/usnic/src/usdf_msg.h
+++ b/prov/usnic/src/usdf_msg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -93,7 +93,8 @@ int usdf_msg_fill_tx_attr(struct fi_info *hints, struct fi_info *fi);
 int usdf_msg_fill_rx_attr(struct fi_info *hints, struct fi_info *fi);
 int usdf_msg_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
 		struct usd_device_attrs *dap);
-int usdf_msg_fill_dom_attr(struct fi_info *hints, struct fi_info *fi);
+int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
+			   struct fi_info *fi, struct usd_device_attrs *dap);
 
 void usdf_msg_ep_timeout(void *vep);
 

--- a/prov/usnic/src/usdf_rdm.h
+++ b/prov/usnic/src/usdf_rdm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -138,10 +138,10 @@ struct usdf_rdm_connection {
 	struct usdf_rdm_connection *dc_hash_next;
 };
 
-
 int usdf_rdm_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
 		struct usd_device_attrs *dap);
-int usdf_rdm_fill_dom_attr(struct fi_info *hints, struct fi_info *fi);
+int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
+			   struct fi_info *fi, struct usd_device_attrs *dap);
 int usdf_rdm_fill_tx_attr(struct fi_info *hints, struct fi_info *fi);
 int usdf_rdm_fill_rx_attr(struct fi_info *hints, struct fi_info *fi);
 

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -46,6 +46,7 @@ int ofi_domain_close(struct util_domain *domain)
 	dlist_remove(&domain->list_entry);
 	fastlock_release(&domain->fabric->lock);
 
+	free(domain->name);
 	fastlock_destroy(&domain->lock);
 	atomic_dec(&domain->fabric->ref);
 	return 0;


### PR DESCRIPTION
Fix #2052 
Still WIP.

One question remains : what exactly should be done with the `strcmp` calls ?
Given that `fattrp->name` has been updated, it is no more equal to `dap->uda_devname`. However, this issue cannot be raised with the `fi_info` tool because this section of code is not reached in this tool.

```
if (fattrp->name != NULL &&
                    strcmp(fattrp->name, dap->uda_devname) != 0) { // CHANGE ??
            fprintf(stderr, "BOOM[1]\n");
            return -FI_ENODATA;
        }
```

The function `build_devname` will be cleaned once that issue has been resolved.
